### PR TITLE
Update renv approach for binaries, caching

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,7 +1,22 @@
-options(repos = c(
-  CRAN = "https://cran.rstudio.com/",
-  RSPM = "https://packagemanager.rstudio.com/all/latest"),
-  renv.config.rspm.enabled = TRUE
+if (file.exists(".env")) {
+  try(readRenviron(".env"), silent = TRUE)
+}
+
+if (Sys.info()[['sysname']] %in% c('Linux', 'Windows')) {
+  options(repos = c(RSPM = "https://packagemanager.rstudio.com/all/latest"))
+} else {
+  ## For Mac users, we'll default to installing from CRAN/MRAN instead, since
+  ## RSPM does not yet support Mac binaries.
+  options(repos = c(CRAN = "https://cran.rstudio.com/"))
+  # options(renv.config.mran.enabled = TRUE) ## TRUE by default
+}
+
+options(
+  renv.config.repos.override = getOption("repos"),
+  renv.config.auto.snapshot = TRUE, ## Attempt to keep renv.lock updated automatically
+  renv.config.rspm.enabled = TRUE, ## Use RStudio Package manager for pre-built package binaries
+  renv.config.install.shortcuts = TRUE, ## Use the existing local library to fetch copies of packages for renv
+  renv.config.cache.enabled = TRUE   ## Use the renv build cache to speed up install times
 )
 
 source("renv/activate.R")

--- a/.Rprofile
+++ b/.Rprofile
@@ -14,7 +14,7 @@ if (Sys.info()[['sysname']] %in% c('Linux', 'Windows')) {
 
 options(
   renv.config.repos.override = getOption("repos"),
-  renv.config.auto.snapshot = TRUE, ## Attempt to keep renv.lock updated automatically
+  renv.config.auto.snapshot = FALSE, ## Don't keep renv.lock updated automatically (messes up GitHub Actions)
   renv.config.rspm.enabled = TRUE, ## Use RStudio Package manager for pre-built package binaries
   renv.config.install.shortcuts = TRUE, ## Use the existing local library to fetch copies of packages for renv
   renv.config.cache.enabled = TRUE   ## Use the renv build cache to speed up install times

--- a/.Rprofile
+++ b/.Rprofile
@@ -7,7 +7,8 @@ if (Sys.info()[['sysname']] %in% c('Linux', 'Windows')) {
 } else {
   ## For Mac users, we'll default to installing from CRAN/MRAN instead, since
   ## RSPM does not yet support Mac binaries.
-  options(repos = c(CRAN = "https://cran.rstudio.com/"))
+  options(repos = c(CRAN = "https://cran.rstudio.com/"),
+          pkgType = "both")
   # options(renv.config.mran.enabled = TRUE) ## TRUE by default
 }
 

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -34,7 +34,7 @@ jobs:
           
       - name: Install packages from renv.lock (with cache)
         if: ${{ !env.ACT }}  ## Doesn't work locally with ACT
-        uses: r-lib/actions/setup-renv@v1
+        uses: r-lib/actions/setup-renv@master
         with:
           cache-version: 1
 

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -31,9 +31,15 @@ jobs:
           apt-get update && apt-get install -y --no-install-recommends \
           libcurl4-openssl-dev \
           libssl-dev
+          
+      - name: Install packages from renv.lock (with cache)
+        if: ${{ !env.ACT }}  ## Doesn't work locally with ACT
+        uses: r-lib/actions/setup-renv@v1
+        with:
+          cache-version: 1
 
-
-      - name: Run targets workflow
+      - name: Install packages from renv.lock (local, no cache)
+        if: ${{ env.ACT }}  ## Only locally with ACT
         run: |
           renv::restore()
         shell: Rscript {0}

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -39,7 +39,7 @@ jobs:
           cache-version: 2
 
       - name: Install packages from renv.lock (local, no cache)
-        if: ${{ env.ACT }}  ## Only locally with ACT
+        if: ${{ env.ACT }}  ## Only locally with ACT, use `act -r` to reuse containers, effectively caching locally
         run: |
           renv::restore()
         shell: Rscript {0}

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -40,4 +40,9 @@ jobs:
         run: |
           targets::tar_make()
         shell: Rscript {0}
+        
+      - name: On failure, launch a temporary interactive debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}
+        timeout-minutes: 15
       

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -32,10 +32,12 @@ jobs:
           libcurl4-openssl-dev \
           libssl-dev
 
-      - uses: r-lib/actions/setup-renv@v1
-        with:
-          cache-version: 1
-    
+
+      - name: Run targets workflow
+        run: |
+          renv::restore()
+        shell: Rscript {0}
+        
       - name: Run targets workflow
         run: |
           targets::tar_make()

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -24,17 +24,17 @@ jobs:
       image: rocker/verse:4.1.2
       
     steps:
+      - uses: actions/checkout@v2
+      
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
           libcurl4-openssl-dev \
           libssl-dev
-          
-      - name: Check out repository
-      - uses: actions/checkout@v2
-      
-      - name: Restore R packages
-        uses: r-lib/actions/setup-renv@v1
+
+      - uses: r-lib/actions/setup-renv@v1
+        with:
+          cache-version: 1
     
       - name: Run targets workflow
         run: |

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ !env.ACT }}  ## Doesn't work locally with ACT
         uses: r-lib/actions/setup-renv@master
         with:
-          cache-version: 1
+          cache-version: 2
 
       - name: Install packages from renv.lock (local, no cache)
         if: ${{ env.ACT }}  ## Only locally with ACT

--- a/.github/workflows/container-workflow-template.yml
+++ b/.github/workflows/container-workflow-template.yml
@@ -24,18 +24,17 @@ jobs:
       image: rocker/verse:4.1.2
       
     steps:
-      - uses: actions/checkout@v2
-      
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
           libcurl4-openssl-dev \
           libssl-dev
+          
+      - name: Check out repository
+      - uses: actions/checkout@v2
       
       - name: Restore R packages
-        run: |
-          renv::restore()
-        shell: Rscript {0}
+        uses: r-lib/actions/setup-renv@v1
     
       - name: Run targets workflow
         run: |

--- a/container-template.Rproj
+++ b/container-template.Rproj
@@ -11,3 +11,5 @@ Encoding: UTF-8
 
 RnwWeave: knitr
 LaTeX: pdfLaTeX
+
+BuildType: Makefile

--- a/renv.lock
+++ b/renv.lock
@@ -3,13 +3,13 @@
     "Version": "4.1.2",
     "Repositories": [
       {
-        "Name": "CRAN",
-        "URL": "https://cloud.r-project.org"
-      },
-      {
         "Name": "RSPM",
         "URL": "https://packagemanager.rstudio.com/all/latest"
-      }      
+      },
+      {
+        "Name": "CRAN",
+        "URL": "https://cloud.r-project.org"
+      }
     ]
   },
   "Packages": {

--- a/renv.lock
+++ b/renv.lock
@@ -3,12 +3,12 @@
     "Version": "4.1.2",
     "Repositories": [
       {
-        "Name": "RSPM",
-        "URL": "https://packagemanager.rstudio.com/all/latest"
-      },
-      {
         "Name": "CRAN",
         "URL": "https://cloud.r-project.org"
+      },
+      {
+        "Name": "RSPM",
+        "URL": "https://packagemanager.rstudio.com/all/latest"
       }
     ]
   },
@@ -36,10 +36,10 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.3-4",
+      "Version": "1.4-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4ed05e9c9726267e4a5872e09c04587c"
+      "Hash": "130c0caba175739d98f2963c6a407cf6"
     },
     "MatrixModels": {
       "Package": "MatrixModels",
@@ -407,10 +407,10 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.5.1",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8142f0a2056d53ec2e15bf701185beb1"
+      "Hash": "7c89603d81793f0d5486d91ab1fc6f1d"
     },
     "future": {
       "Package": "future",
@@ -722,10 +722,10 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-152",
+      "Version": "3.1-153",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "35de1ce639f20b5e10f7f46260730c65"
+      "Hash": "2d632e0d963a653a0329756ce701ecdd"
     },
     "nloptr": {
       "Package": "nloptr",


### PR DESCRIPTION
 - Fix .Rprofile to always install binaries on Linux
 - Use pre-canned `renv` action that includes package caching
 - Don't use pre-canned action when running locally with `act`, where caching doesn't work
 - Turn off autosnapshotting, which clashes with the precanned `renv` actions
 - Add interactive debugging on failure 

Makes things run nice and fast! (https://github.com/ecohealthalliance/container-template/runs/4477107600?check_suite_focus=true)
