### PR TITLE
add namespace of s3() and keep() functions in aws_upload function for use in command line

### DIFF
--- a/R/utils-aws-upload.R
+++ b/R/utils-aws-upload.R
@@ -49,7 +49,7 @@ aws_s3_upload <- function(path, bucket, key = basename(path), prefix = "",
     }
   }
   
-  svc <- s3()
+  svc <- paws::s3()
   if (file.exists(path) && !dir.exists(path)) {
     out <- list(aws_s3_upload_single(path, paste0(key, prefix), bucket, check, svc))
   } else if (file.exists(path) && dir.exists(path)) {
@@ -82,7 +82,7 @@ aws_s3_upload_single <- function(path, key = basename(path), bucket,
   if (check) {
     local_hash <- paste0('"', tools::md5sum(path), '"')
     s3_obj <- svc$list_objects_v2(Bucket = bucket, Prefix = key)$Contents |>
-      keep(~ .x$Key == key) |>
+      purrr::keep(~ .x$Key == key) |>
       unlist(FALSE)
     
     if (!is.null(s3_obj) && s3_obj$ETag == local_hash) {


### PR DESCRIPTION
when I used the aws_upload function in the GHA workflow, i encountered these errors:

https://github.com/ecohealthalliance/nipah-bangladesh-automation/runs/4532950083?check_suite_focus=true
https://github.com/ecohealthalliance/nipah-bangladesh-automation/runs/4533008761?check_suite_focus=true

adding `paws::s3()` and `purrr::keep()` sorted the issue 
